### PR TITLE
OnLandEvent() Triggers Prematurely

### DIFF
--- a/CharacterController2D.cs
+++ b/CharacterController2D.cs
@@ -127,7 +127,6 @@ public class CharacterController2D : MonoBehaviour
 		if (m_Grounded && jump)
 		{
 			// Add a vertical force to the player.
-			m_Grounded = false;
 			m_Rigidbody2D.AddForce(new Vector2(0f, m_JumpForce));
 		}
 	}


### PR DESCRIPTION
By leaving the line `m_Grounded = false;` in the statement `if (m_Grounded && jump)` it will cause in some cases for the `OnLandEvent()` to be triggered prematurely. This is because when `m_Grounded = false;` it will cause `wasGrounded` to be equal to false and therefore trigger the `OnLandEvent()` when `m_Grounded = false;` and therefore `wasGrounded` should actually equal true because it **_was_** grounded previously.