### PR TITLE
Do not disable the boxCollider when jumping

### DIFF
--- a/CharacterController2D.cs
+++ b/CharacterController2D.cs
@@ -64,7 +64,7 @@ public class CharacterController2D : MonoBehaviour
 	public void Move(float move, bool crouch, bool jump)
 	{
 		// If crouching, check to see if the character can stand up
-		if (!crouch)
+		if (!crouch && m_Grounded)
 		{
 			// If the character has a ceiling preventing them from standing up, keep them crouching
 			if (Physics2D.OverlapCircle(m_CeilingCheck.position, k_CeilingRadius, m_WhatIsGround))


### PR DESCRIPTION
If, while jumping, the ceilingCheck hits something, it disables the boxCollider, which is unwanted.