### PR TITLE
Fix typo that may cause crouch to always be true

### DIFF
--- a/CharacterController2D.cs
+++ b/CharacterController2D.cs
@@ -64,7 +64,7 @@ public class CharacterController2D : MonoBehaviour
 	public void Move(float move, bool crouch, bool jump)
 	{
 		// If crouching, check to see if the character can stand up
-		if (!crouch)
+		if (crouch)
 		{
 			// If the character has a ceiling preventing them from standing up, keep them crouching
 			if (Physics2D.OverlapCircle(m_CeilingCheck.position, k_CeilingRadius, m_WhatIsGround))


### PR DESCRIPTION
A typo in the `if` statement in line 67 may cause the `crouch` bool to always check `true`. This revision simply changes the `(!crouch)` in line 67 to the intended `(crouch)` so that the script works as expected. Thank you!