### PR TITLE
Adding the CancelFormerMomentumOnJump option on the script

### DIFF
--- a/CharacterController2D.cs
+++ b/CharacterController2D.cs
@@ -4,7 +4,8 @@ using UnityEngine.Events;
 public class CharacterController2D : MonoBehaviour
 {
 	[SerializeField] private float m_JumpForce = 400f;							// Amount of force added when the player jumps.
-	[Range(0, 1)] [SerializeField] private float m_CrouchSpeed = .36f;			// Amount of maxSpeed applied to crouching movement. 1 = 100%
+    public bool cancelFormerMomentumOnJump = false;                             // If the former momentum should be canceled before the player jumps. Turning it on will always make the player jump the same amount, even if it is going down or up
+    [Range(0, 1)] [SerializeField] private float m_CrouchSpeed = .36f;			// Amount of maxSpeed applied to crouching movement. 1 = 100%
 	[Range(0, .3f)] [SerializeField] private float m_MovementSmoothing = .05f;	// How much to smooth out the movement
 	[SerializeField] private bool m_AirControl = false;							// Whether or not a player can steer while jumping;
 	[SerializeField] private LayerMask m_WhatIsGround;							// A mask determining what is ground to the character
@@ -128,7 +129,10 @@ public class CharacterController2D : MonoBehaviour
 		{
 			// Add a vertical force to the player.
 			m_Grounded = false;
-			m_Rigidbody2D.AddForce(new Vector2(0f, m_JumpForce));
+            if (cancelFormerMomentumOnJump) {
+                m_Rigidbody2D.velocity = new Vector2(m_Rigidbody2D.velocity.x, 0);
+            }
+            m_Rigidbody2D.AddForce(new Vector2(0f, m_JumpForce));
 		}
 	}
 


### PR DESCRIPTION
Fixing issue #11 

A boolean check was added to cancel former momentum on jump. Checking it will make the former momentum be canceled before the player jumps, resulting on the player always jumping the same amount, even if it is going down or up. In my experience, this makes the player feel a lot better.