### PR TITLE
Possible bugs, if you dont need crouching

### DIFF
--- a/CharacterController2D.cs
+++ b/CharacterController2D.cs
@@ -64,7 +64,7 @@ public class CharacterController2D : MonoBehaviour
 	public void Move(float move, bool crouch, bool jump)
 	{
 		// If crouching, check to see if the character can stand up
-		if (!crouch)
+		if (crouch)
 		{
 			// If the character has a ceiling preventing them from standing up, keep them crouching
 			if (Physics2D.OverlapCircle(m_CeilingCheck.position, k_CeilingRadius, m_WhatIsGround))


### PR DESCRIPTION
There is a bug in new version of the script for movement. On line 67, I guess they accidentally put !crouch instead of crouch. This bug makes your character be always in the crouch position and that causes few bugs like EXTRALARGE jump while moving. Just delete "!" from if(!crouch){... and done! 
P.S ty to guys from comments of youtube video for finding this bug.
Link on video : https://www.youtube.com/watch?v=dwcT-Dch0bA