### PR TITLE
Fix unintentional crouch bug

### DIFF
--- a/CharacterController2D.cs
+++ b/CharacterController2D.cs
@@ -64,7 +64,7 @@ public class CharacterController2D : MonoBehaviour
 	public void Move(float move, bool crouch, bool jump)
 	{
 		// If crouching, check to see if the character can stand up
-		if (!crouch)
+		if (m_wasCrouching)
 		{
 			// If the character has a ceiling preventing them from standing up, keep them crouching
 			if (Physics2D.OverlapCircle(m_CeilingCheck.position, k_CeilingRadius, m_WhatIsGround))


### PR DESCRIPTION
2D Character Controller unintentionally crouches when a character hits the ceiling. It's caused by checking for a ceiling while the character is standing (`!crouch`), causing it to crouch everytime the ceiling is hit.

Simple fix was to check if the character previously crouched (`m_wasCrouching`) instead. This way it only checks for a ceiling if it was already crouching.